### PR TITLE
unify dts-client groupId to com.alibaba.dts.client

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
 
     <dependency>
-        <groupId>com.aliyun.dts</groupId>
+        <groupId>com.alibaba.dts.client</groupId>
         <artifactId>dts-client</artifactId>
         <version>${revision}</version>
     </dependency>

--- a/dts-client/pom.xml
+++ b/dts-client/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.aliyun.dts</groupId>
+    <groupId>com.alibaba.dts.client</groupId>
     <artifactId>dts-client</artifactId>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
Central Portal requires a single namespace per deployment. The dts-client module used com.aliyun.dts while all other modules use com.alibaba.dts.client, causing "multiple namespaces" validation failure.

- dts-client/pom.xml: groupId com.aliyun.dts -> com.alibaba.dts.client
- client/pom.xml: dts-client dependency groupId aligned accordingly


AI-Contributed/Feature: 4/4
AI-Contributed/UT: 0/0