### PR TITLE
replace togo SNAPSHOT dep with released togo-clients:1.0.0.45

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,8 +33,14 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.taobao.togo</groupId>
-            <artifactId>clients</artifactId>
+            <groupId>com.alibaba.dts.client</groupId>
+            <artifactId>togo-clients</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -45,8 +45,14 @@
             <artifactId>avro</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.taobao.togo</groupId>
-            <artifactId>clients</artifactId>
+            <groupId>com.alibaba.dts.client</groupId>
+            <artifactId>togo-clients</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,9 @@
                 <version>1.0</version>
             </dependency>
             <dependency>
-                <groupId>com.taobao.togo</groupId>
-                <artifactId>clients</artifactId>
-                <version>1.0.0.40-SNAPSHOT</version>
+                <groupId>com.alibaba.dts.client</groupId>
+                <artifactId>togo-clients</artifactId>
+                <version>1.0.0.45</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Maven Central release forbids SNAPSHOT dependencies. Switch the togo dependency to the released, API-compatible artifact (verified superset: same 151 togo classes, identical public API).

- root/message/common: com.taobao.togo:clients:1.0.0.40-SNAPSHOT -> com.alibaba.dts.client:togo-clients:1.0.0.45
- exclude togo-clients' log4j-slf4j-impl to avoid SLF4J multiple-bindings conflict with the project's existing slf4j-log4j12


AI-Contributed/Feature: 26/26
AI-Contributed/UT: 0/0