### PR TITLE
Upgrade to fastjson2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
             <version>2.7.0</version>
         </dependency>
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-            <version>1.2.31</version>
+            <groupId>com.alibaba.fastjson2</groupId>
+            <artifactId>fastjson2</artifactId>
+            <version>2.0.61</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/aliyun/dms/subscribe/clients/DBMapper.java
+++ b/src/main/java/com/aliyun/dms/subscribe/clients/DBMapper.java
@@ -1,6 +1,6 @@
 package com.aliyun.dms.subscribe.clients;
 
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson2.JSONObject;
 import com.aliyun.dts.subscribe.clients.common.RetryUtil;
 import com.aliyun.dts.subscribe.clients.formats.avro.Operation;
 import com.aliyun.dts.subscribe.clients.formats.avro.Record;

--- a/src/main/java/com/aliyun/dts/subscribe/clients/metastore/AbstractUserMetaStore.java
+++ b/src/main/java/com/aliyun/dts/subscribe/clients/metastore/AbstractUserMetaStore.java
@@ -1,7 +1,7 @@
 package com.aliyun.dts.subscribe.clients.metastore;
 
-import com.alibaba.fastjson.JSONArray;
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 import com.aliyun.dts.subscribe.clients.common.Checkpoint;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.TopicPartition;

--- a/src/main/java/com/aliyun/dts/subscribe/clients/metastore/LocalFileMetaStore.java
+++ b/src/main/java/com/aliyun/dts/subscribe/clients/metastore/LocalFileMetaStore.java
@@ -1,7 +1,7 @@
 package com.aliyun.dts.subscribe.clients.metastore;
 
-import com.alibaba.fastjson.JSONArray;
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 import com.aliyun.dts.subscribe.clients.common.AtomicFileStore;
 import com.aliyun.dts.subscribe.clients.common.Checkpoint;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/com/aliyun/dts/subscribe/clients/metrics/LogMetricsReporter.java
+++ b/src/main/java/com/aliyun/dts/subscribe/clients/metrics/LogMetricsReporter.java
@@ -1,6 +1,6 @@
 package com.aliyun.dts.subscribe.clients.metrics;
 
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson2.JSONObject;
 import com.aliyun.dts.subscribe.clients.common.ThreadFactoryWithNamePrefix;
 import com.aliyun.dts.subscribe.clients.exception.DTSBaseException;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/com/aliyun/dts/subscribe/clients/record/AvroRecordParser.java
+++ b/src/main/java/com/aliyun/dts/subscribe/clients/record/AvroRecordParser.java
@@ -1,8 +1,8 @@
 package com.aliyun.dts.subscribe.clients.record;
 
-import com.alibaba.fastjson.JSONArray;
-import com.alibaba.fastjson.JSONObject;
-import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 
 import com.aliyun.dts.subscribe.clients.exception.DTSBaseException;
 import com.aliyun.dts.subscribe.clients.formats.avro.DefaultValueDeserializer;

--- a/src/main/java/com/aliyun/dts/subscribe/clients/record/fast/LazyRecordDeserializer.java
+++ b/src/main/java/com/aliyun/dts/subscribe/clients/record/fast/LazyRecordDeserializer.java
@@ -1,8 +1,8 @@
 package com.aliyun.dts.subscribe.clients.record.fast;
 
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONArray;
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 import com.aliyun.dts.subscribe.clients.formats.avro.SourceType;
 import com.aliyun.dts.subscribe.clients.formats.util.ObjectNameUtils;
 import com.aliyun.dts.subscribe.clients.record.*;

--- a/src/test/java/com/aliyun/dts/subscribe/clients/Fastjson2CompatibilityTest.java
+++ b/src/test/java/com/aliyun/dts/subscribe/clients/Fastjson2CompatibilityTest.java
@@ -1,0 +1,22 @@
+package com.aliyun.dts.subscribe.clients;
+
+import com.aliyun.dms.subscribe.clients.DBMapper;
+import com.aliyun.dts.subscribe.clients.formats.avro.Operation;
+import com.aliyun.dts.subscribe.clients.formats.avro.Record;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Fastjson2CompatibilityTest {
+
+    @Test
+    public void mapsPhysicalTableNameFromDtsMetadata() {
+        DBMapper dbMapper = new DBMapper();
+        dbMapper.init("{\"physical_db\":{\"name\":\"logical_db\",\"Table\":{\"physical_table\":{\"name\":\"logical_table\"}}}}");
+
+        Record record = new Record();
+        record.setOperation(Operation.UPDATE);
+        record.setObjectName("physical_db.physical_table");
+
+        Assert.assertEquals("logical_db.logical_table", dbMapper.transform(record).getObjectName());
+    }
+}

--- a/src/test/java/com/aliyun/dts/subscribe/clients/metastore/MetaStoreJsonCompatibilityTest.java
+++ b/src/test/java/com/aliyun/dts/subscribe/clients/metastore/MetaStoreJsonCompatibilityTest.java
@@ -1,0 +1,71 @@
+package com.aliyun.dts.subscribe.clients.metastore;
+
+import com.aliyun.dts.subscribe.clients.common.Checkpoint;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class MetaStoreJsonCompatibilityTest {
+
+    private static final String GROUP_ID = "subscription-group";
+    private static final TopicPartition TOPIC_PARTITION = new TopicPartition("dts-topic", 0);
+    private static final String LEGACY_CHECKPOINT_JSON = "{\"groupID\":\"subscription-group\","
+            + "\"streamCheckpoint\":[{\"topic\":\"dts-topic\",\"partition\":0,\"offset\":42,"
+            + "\"timestamp\":1720000000,\"info\":\"legacy-checkpoint\"}]}";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void abstractUserMetaStoreReadsLegacyCheckpointAndRoundTripsWithFastjson2() throws Exception {
+        InMemoryMetaStore metaStore = new InMemoryMetaStore();
+        metaStore.storedData = LEGACY_CHECKPOINT_JSON;
+
+        assertCheckpoint(metaStore.deserializeFrom(TOPIC_PARTITION, GROUP_ID));
+
+        Checkpoint checkpoint = new Checkpoint(TOPIC_PARTITION, 1720000000L, 42L, "legacy-checkpoint");
+        metaStore.serializeTo(TOPIC_PARTITION, GROUP_ID, checkpoint).get();
+
+        InMemoryMetaStore reloadedMetaStore = new InMemoryMetaStore();
+        reloadedMetaStore.storedData = metaStore.storedData;
+        assertCheckpoint(reloadedMetaStore.deserializeFrom(TOPIC_PARTITION, GROUP_ID));
+    }
+
+    @Test
+    public void localFileMetaStoreReadsLegacyCheckpoint() throws Exception {
+        File checkpointFile = temporaryFolder.newFile("checkpoint.json");
+        Files.write(checkpointFile.toPath(), LEGACY_CHECKPOINT_JSON.getBytes(StandardCharsets.UTF_8));
+
+        LocalFileMetaStore metaStore = new LocalFileMetaStore(checkpointFile.getAbsolutePath());
+
+        assertCheckpoint(metaStore.deserializeFrom(TOPIC_PARTITION, GROUP_ID));
+    }
+
+    private static void assertCheckpoint(Checkpoint checkpoint) {
+        Assert.assertNotNull(checkpoint);
+        Assert.assertEquals(TOPIC_PARTITION, checkpoint.getTopicPartition());
+        Assert.assertEquals(1720000000L, checkpoint.getTimeStamp());
+        Assert.assertEquals(42L, checkpoint.getOffset());
+        Assert.assertEquals("legacy-checkpoint", checkpoint.getInfo());
+    }
+
+    private static class InMemoryMetaStore extends AbstractUserMetaStore {
+        private String storedData;
+
+        @Override
+        protected void saveData(String groupID, String toStoreJson) {
+            storedData = toStoreJson;
+        }
+
+        @Override
+        protected String getData(String groupID) {
+            return storedData;
+        }
+    }
+}

--- a/src/test/java/com/aliyun/dts/subscribe/clients/record/fast/LazyRecordDeserializerJsonTest.java
+++ b/src/test/java/com/aliyun/dts/subscribe/clients/record/fast/LazyRecordDeserializerJsonTest.java
@@ -1,0 +1,28 @@
+package com.aliyun.dts.subscribe.clients.record.fast;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class LazyRecordDeserializerJsonTest {
+
+    @Test
+    public void deserializesPrimaryAndUniqueKeyMetadata() throws Exception {
+        Pair<Map<String, Boolean>, Map<String, Pair<Boolean, List<String>>>> result =
+                LazyRecordDeserializer.deserializePkUkInfo(
+                        "{\"PRIMARY\":[\"id\"],\"uk_tenant_name\":[\"tenant_id\",\"name\"]}");
+
+        Assert.assertTrue(result.getLeft().get("id"));
+        Assert.assertFalse(result.getLeft().get("tenant_id"));
+        Assert.assertFalse(result.getLeft().get("name"));
+        Assert.assertTrue(result.getRight().get("PRIMARY").getLeft());
+        Assert.assertEquals(Arrays.asList("id"), result.getRight().get("PRIMARY").getRight());
+        Assert.assertFalse(result.getRight().get("uk_tenant_name").getLeft());
+        Assert.assertEquals(Arrays.asList("tenant_id", "name"),
+                result.getRight().get("uk_tenant_name").getRight());
+    }
+}


### PR DESCRIPTION
## What changed

- replace `com.alibaba:fastjson:1.2.31` with `com.alibaba.fastjson2:fastjson2:2.0.61`;
- migrate the six internal JSON call sites to the fastjson2 package;
- add regression coverage for DTS table mapping, `pk_uk_info` parsing, checkpoint round trips, and checkpoint JSON written by the fastjson1 version.

The SDK does not expose fastjson types through its public API, so this change does not require any change from SDK users. Existing checkpoint JSON remains readable.

## Why

The current fastjson1 dependency is compile-scoped, so it is inherited by SDK users and is also included in the assembled `jar-with-dependencies`. Moving the SDK itself to fastjson2 removes that dependency from downstream applications instead of requiring every user to exclude or override it independently.

Closes #95.

## Validation

- `mvn -Dmaven.repo.local=/tmp/aliyun-dts-m2 -Dtest=Fastjson2CompatibilityTest,MetaStoreJsonCompatibilityTest,LazyRecordDeserializerJsonTest test`
  - 4 migration regression tests passed.
- `mvn -Dmaven.repo.local=/tmp/aliyun-dts-m2 -DskipTests package`
  - regular and `jar-with-dependencies` artifacts built successfully.
- Maven dependency tree contains only `com.alibaba.fastjson2:fastjson2:2.0.61` for Fastjson.
- The assembled JAR contains `com/alibaba/fastjson2/**` and no `com/alibaba/fastjson/**` classes.

I also ran the complete existing test suite. Its five remaining failures reproduce on the unmodified `master` branch: `DBMapperTest` expects DDL mapping although DDL mapping is disabled in the implementation, and four `DateTimeTest` cases access a non-exported JDK internal package when run on JDK 21. These failures are unrelated to this migration and are not changed in this PR.
